### PR TITLE
Fixed issue in the `transform_response` function

### DIFF
--- a/SDK Submissions/chimoney-rs/src/schema/responses.rs
+++ b/SDK Submissions/chimoney-rs/src/schema/responses.rs
@@ -17,7 +17,20 @@ pub struct GoodResponse<T> {
 #[derive(Debug, Deserialize)]
 pub struct ErrorResponse {
     pub status: String,
+    pub error: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessageResponse {
     pub message: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseEnum<T> {
+    Good(GoodResponse<T>),
+    Error(ErrorResponse),
+    Message(MessageResponse),
 }
 
 pub type AirtimeCountriesResponse = Vec<String>;

--- a/SDK Submissions/chimoney-rs/tests/info.rs
+++ b/SDK Submissions/chimoney-rs/tests/info.rs
@@ -15,5 +15,6 @@ async fn info_airtime_countries_works() {
         .await
         .expect("unable to get airtime countries");
 
+    println!("{res:?}");
     assert!(!res.is_empty());
 }


### PR DESCRIPTION
I fixed an issue whereby due to the poor implementation of the base chimoney HTTP API, errors where not returned in the correct format. So I created an enum to capture all the responses and parse it out with Serde